### PR TITLE
Minor build fixes for Linux/Macs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,14 @@ target_include_directories(obj_parse_tester PRIVATE
 	libs/blender
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 target_link_libraries(obj_parse_tester
 	tinyobjloader
 	xxHash::xxhash
 	fast_obj_lib
+        rapidobj::rapidobj
 	assimp::assimp
-	${CMAKE_SOURCE_DIR}/libs/blender/pthreads/lib/pthreadVC3.lib)
+        Threads::Threads
+)

--- a/obj_parse_tester.cpp
+++ b/obj_parse_tester.cpp
@@ -22,7 +22,7 @@
 
 static std::chrono::steady_clock::time_point get_time()
 {
-    return std::chrono::high_resolution_clock::now();
+    return std::chrono::steady_clock::now();
 }
 static double get_duration(std::chrono::steady_clock::time_point since)
 {


### PR DESCRIPTION
Hello!

Thanks for making this benchmark public, it was very interesting to try it out and compare it with my own Obj parser (even if it was the second slowest of the bunch, but with more features!)

That said, I found a few build and compilation errors which I figured I could contribute back if they were of interest. I did verify it on Linux and Macs, but I don't have a Windows box available so I'm not sure if it will work there. That said, I does cross-compile with mingw64 and run in wine, so it might be fine.

All in all, these are the fixes:

- Use find_package to find threads packages.
- Fixed missing linker flags to rapidobj::rapidobj.
- Fixed compile error in `get_time()` when `high_resolution_clock` is not a `steady_clock`.